### PR TITLE
Publish to GitHub Container Registry

### DIFF
--- a/.github/workflows/ci-job.yml
+++ b/.github/workflows/ci-job.yml
@@ -6,7 +6,7 @@ name: Test and Build CI
 on:
   push:
     branches:
-      - "tool-ci-job"
+      - "*"
 
 jobs:
   build-test-matrix:
@@ -49,11 +49,11 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.REGISTRY_USER }}
+          password: ${{ secrets.REGISTRY_TOKEN }}
       
       - name: Build and push
         uses: docker/build-push-action@v4
         with:
           push: true
-          tags: ghcr.io/RE-MAT/re-mat-data-tool:${{ steps.extract_branch.outputs.branch }}
+          tags: ghcr.io/re-mat/re-mat-data-tool:${{ steps.extract_branch.outputs.branch }}

--- a/.github/workflows/ci-job.yml
+++ b/.github/workflows/ci-job.yml
@@ -44,15 +44,16 @@ jobs:
       
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      
-      - name: Login to Docker Hub
+
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Build and push
         uses: docker/build-push-action@v4
         with:
           push: true
-          tags: stayal2/re-mat-data-tool:${{ steps.extract_branch.outputs.branch }}
+          tags: ghcr.io/RE-MAT/re-mat-data-tool:${{ steps.extract_branch.outputs.branch }}


### PR DESCRIPTION
# Problem
The CI job should not publish the built docker image to a private registry

# Approach
DockerHub has become less friendly. Publish to the RE-MAT GitHub organization's container registry. 

This requires a personal access token (due to this repo being a fork. We might want to consider unforking at some point since we are making some pretty big changes which will make future merge's unlikely). 

Changed the GHA to build a docker image for any branch.

The images are now available with 
```shell
% docker pull ghcr.io/re-mat/re-mat-data-tool:main
```
